### PR TITLE
Add Super CSV-based TabularDataSource

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+*   2.1.0
+    *   Add Super CSV-based `TabularDataSource`
+    *   Deprecate opencsv-based `TabularDataSource`; the Super CSV-based `TabularDataSource` should be used instead.
+
 *   2.0.1
     *   Upgrade to POI 3.10.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 # Change Log
 
 *   2.1.0
-    *   Add Super CSV-based `TabularDataSource`
+    *   Add [Super CSV](http://super-csv.github.io/super-csv/)-based `TabularDataSource`
     *   Deprecate opencsv-based `TabularDataSource`; the Super CSV-based `TabularDataSource` should be used instead.
 
 *   2.0.1

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Maven:
 </dependency>
 ```
 
-Next, create the desired instance of `TabularDataSource`. Please note that
-`com.commercehub.griddle.opencsv.CSVTabularDataSource` is deprecated; use
-`com.commercehub.griddle.supercsv.CSVTabularDataSource` instead.
+Next, create the desired instance of `TabularDataSource`.
+
+Please note that `com.commercehub.griddle.opencsv.CSVTabularDataSource` is deprecated; use `com.commercehub.griddle.supercsv.CSVTabularDataSource` instead.
 
 ```groovy
 def tabularDataSource = new CSVTabularDataSource()

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ Maven:
 Next, create the desired instance of `TabularDataSource`.
 
 ```groovy
-def tabularDataSource = new CSVTabularDataSource()
+def tabularDataSource = new com.commercehub.griddle.supercsv.CSVTabularDataSource()
+// OR
+def tabularDataSource = new com.commercehub.griddle.opencsv.CSVTabularDataSource()
 // OR
 def tabularDataSource = new HSSFTabularDataSource()
 // OR

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ repositories {
     jcenter()
 }
 dependencies {
-    compile "com.commercehub:griddle:1.0.0"
+    compile "com.commercehub:griddle:2.1.0"
 }
 ```
 
@@ -25,7 +25,7 @@ Maven:
 <dependency>
     <groupId>com.commercehub</groupId>
     <artifactId>griddle</artifactId>
-    <version>1.0.0</version>
+    <version>2.1.0</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ Maven:
 </dependency>
 ```
 
-Next, create the desired instance of `TabularDataSource`.
+Next, create the desired instance of `TabularDataSource`. Please note that
+`com.commercehub.griddle.opencsv.CSVTabularDataSource` is deprecated; use
+`com.commercehub.griddle.supercsv.CSVTabularDataSource` instead.
 
 ```groovy
 def tabularDataSource = new CSVTabularDataSource()

--- a/README.md
+++ b/README.md
@@ -32,9 +32,7 @@ Maven:
 Next, create the desired instance of `TabularDataSource`.
 
 ```groovy
-def tabularDataSource = new com.commercehub.griddle.supercsv.CSVTabularDataSource()
-// OR
-def tabularDataSource = new com.commercehub.griddle.opencsv.CSVTabularDataSource()
+def tabularDataSource = new CSVTabularDataSource()
 // OR
 def tabularDataSource = new HSSFTabularDataSource()
 // OR

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ repositories {
 dependencies {
     compile "org.codehaus.groovy:groovy-all:2.2.1"
     compile "net.sf.opencsv:opencsv:2.3"
+    compile "net.sf.supercsv:super-csv:2.2.1"
 
     def poiVersion = "3.10.1"
     compile "org.apache.poi:poi:${poiVersion}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.0.2
+version=2.1.0

--- a/src/main/groovy/com/commercehub/griddle/opencsv/CSVTabularData.groovy
+++ b/src/main/groovy/com/commercehub/griddle/opencsv/CSVTabularData.groovy
@@ -5,6 +5,7 @@ import com.commercehub.griddle.TabularData
 
 import static au.com.bytecode.opencsv.CSVParser.*
 
+@Deprecated
 class CSVTabularData implements TabularData, Closeable {
 
     private File file

--- a/src/main/groovy/com/commercehub/griddle/opencsv/CSVTabularDataSource.groovy
+++ b/src/main/groovy/com/commercehub/griddle/opencsv/CSVTabularDataSource.groovy
@@ -2,6 +2,11 @@ package com.commercehub.griddle.opencsv
 
 import com.commercehub.griddle.BaseTabularDataSource
 
+/**
+ * @deprecated This class will be removed in a future release. Use
+ * {@link com.commercehub.griddle.supercsv.CSVTabularDataSource} instead, which is a drop-in replacement.
+ */
+@Deprecated
 class CSVTabularDataSource extends BaseTabularDataSource {
 
     @Override

--- a/src/main/groovy/com/commercehub/griddle/opencsv/RowIterator.groovy
+++ b/src/main/groovy/com/commercehub/griddle/opencsv/RowIterator.groovy
@@ -2,6 +2,7 @@ package com.commercehub.griddle.opencsv
 
 import au.com.bytecode.opencsv.CSVReader
 
+@Deprecated
 class RowIterator implements Iterator<Map<String, String>> {
 
     private final CSVReader reader

--- a/src/main/groovy/com/commercehub/griddle/supercsv/CSVTabularData.groovy
+++ b/src/main/groovy/com/commercehub/griddle/supercsv/CSVTabularData.groovy
@@ -1,0 +1,80 @@
+package com.commercehub.griddle.supercsv
+
+import com.commercehub.griddle.TabularData
+import org.supercsv.io.CsvMapReader
+import org.supercsv.io.ICsvMapReader
+import org.supercsv.prefs.CsvPreference
+
+class CSVTabularData implements TabularData, Closeable {
+
+    private File file
+    private final Closure<String> valueTransformer
+    private final Map<Integer,String> transformedColumnNamesByIndex
+    private final List<String> transformedColumnNames
+    private final List<ICsvMapReader> readers = []
+
+    CSVTabularData(File file, Closure<String> columnNameTransformer, Closure<String> valueTransformer) {
+        this.file = file
+        this.valueTransformer = valueTransformer
+
+        transformedColumnNamesByIndex = [:]
+        transformedColumnNames = []
+
+        def reader = openReader()
+        try {
+            def headerRow = Arrays.asList(reader.getHeader(true))
+            headerRow?.eachWithIndex { String columnName, int index ->
+                def transformedColumnName = columnNameTransformer(columnName)
+                if (transformedColumnName) {
+                    transformedColumnNamesByIndex[index] = transformedColumnName
+                    transformedColumnNames << transformedColumnName
+                }
+            }
+        } finally {
+            closeReader(reader)
+        }
+    }
+
+    @Override
+    List<String> getColumnNames() {
+        return Collections.unmodifiableList(transformedColumnNames)
+    }
+
+    @Override
+    Iterable<Map<String, String>> getRows() {
+        return getRows(NEVER_SKIP)
+    }
+
+    @Override
+    Iterable<Map<String, String>> getRows(Closure<Boolean> rowSkipCriteria) {
+        return {
+            new RowIterator(openReader(), transformedColumnNamesByIndex, valueTransformer, rowSkipCriteria)
+        } as Iterable<Map<String, String>>
+    }
+
+    @Override
+    void close() {
+        file = null
+        for (reader in new ArrayList<ICsvMapReader>(readers)) {
+            closeReader(reader)
+        }
+    }
+
+    private ICsvMapReader openReader() {
+        if (file == null) {
+            throw new IllegalStateException("No file available")
+        }
+
+        def reader = new CsvMapReader(new FileReader(file), CsvPreference.STANDARD_PREFERENCE)
+        readers << reader
+        return reader
+    }
+
+    private void closeReader(ICsvMapReader reader) {
+        try {
+            reader.close()
+        } catch (IOException ignored) { }
+        readers.remove(reader)
+    }
+
+}

--- a/src/main/groovy/com/commercehub/griddle/supercsv/CSVTabularDataSource.groovy
+++ b/src/main/groovy/com/commercehub/griddle/supercsv/CSVTabularDataSource.groovy
@@ -1,0 +1,17 @@
+package com.commercehub.griddle.supercsv
+
+import com.commercehub.griddle.BaseTabularDataSource
+
+class CSVTabularDataSource extends BaseTabularDataSource {
+
+    @Override
+    void withFile(File file, Closure tableHandler) {
+        def table = new CSVTabularData(file, columnNameTransformer, valueTransformer)
+        try {
+            tableHandler([table])
+        } finally {
+            table.close()
+        }
+    }
+
+}

--- a/src/test/groovy/com/commercehub/griddle/supercsv/CSVTabularDataSourceSpec.groovy
+++ b/src/test/groovy/com/commercehub/griddle/supercsv/CSVTabularDataSourceSpec.groovy
@@ -1,0 +1,70 @@
+package com.commercehub.griddle.supercsv
+
+import com.commercehub.griddle.TabularData
+import spock.lang.Specification
+
+class CSVTabularDataSourceSpec extends Specification {
+
+    private static final File FILE1 = getFile("/csv/csv1.csv")
+    private static final File FILE_WITH_MISSING_COLUMN_NAME = getFile("/csv/csv-with-missing-column-name.csv")
+
+    def tabularDataSource = new CSVTabularDataSource()
+
+    def "withFile produces one table per file"() {
+        int actualTableCount = -1
+
+        when:
+        tabularDataSource.withFile(file) { Iterable<TabularData> tables ->
+            actualTableCount = tables.collect().size()
+        }
+
+        then:
+        actualTableCount == 1
+
+        where:
+        file                            | _
+        FILE1                           | _
+        FILE_WITH_MISSING_COLUMN_NAME   | _
+    }
+
+    @SuppressWarnings("LineLength")
+    def "tables have expected columnNames"() {
+        def actualColumnNames = null
+
+        when:
+        tabularDataSource.withFile(file) { Iterable<TabularData> tables ->
+            actualColumnNames = tables.first().columnNames.collect()
+        }
+
+        then:
+        actualColumnNames == expectedColumnNames
+
+        where:
+        file                            | expectedColumnNames
+        FILE1                           | ["Foo", "Bar", "Moo", "Goo"]
+        FILE_WITH_MISSING_COLUMN_NAME   | ["Column 1", "Column 2", "Column 4"]
+    }
+
+    @SuppressWarnings("LineLength")
+    def "table rows have expected values"() {
+        def actualRows = null
+
+        when:
+            tabularDataSource.withFile(file) { Iterable<TabularData> tables ->
+                actualRows = tables.first().rows.collect()
+            }
+
+        then:
+            actualRows == expectedRows
+
+        where:
+            file                            | expectedRows
+            FILE1                           | [["Foo":"Lorem", "Bar":"ipsum", "Moo":"dolor", "Goo":"sit"], ["Foo":"12.1", "Bar":"amet", "Moo":"consectetur", "Goo":"7"], ["Foo":"adipisicing", "Bar":"1000", "Moo":"22.1241", "Goo":"elit, sed do"]]
+            FILE_WITH_MISSING_COLUMN_NAME   | [["Column 1":"Row 1 Column 1", "Column 4":"Row 1 Column 4"], ["Column 1":"Row 3 Column 1", "Column 2":"Row 3 Column 2", "Column 4":"Row 3 Column 4"], ["Column 1":"Row 4 Column 1", "Column 2":"Row 4 Column 2", "Column 4":"Row 4 Column 4"]]
+    }
+
+    private static File getFile(String resourcePath) {
+        return new File(CSVTabularDataSource.getResource(resourcePath).toURI())
+    }
+
+}


### PR DESCRIPTION
Add a new Super CSV-based `TabularDataSource`. For backward-compatibility, the existing opencsv-based `TabularDataSource` was left untouched. Perhaps we should mark it as deprecated?

This will resolve #9 