### PR TITLE
Add type to StreamingXSSFTabularData#use1904DateWindowing

### DIFF
--- a/src/main/groovy/com/commercehub/griddle/poi/streaming/StreamingXSSFTabularData.groovy
+++ b/src/main/groovy/com/commercehub/griddle/poi/streaming/StreamingXSSFTabularData.groovy
@@ -24,7 +24,7 @@ class StreamingXSSFTabularData implements TabularData {
     protected final List<String> transformedColumnNames
 
     protected SheetDataContainer dataContainer
-    protected use1904DateWindowing
+    protected boolean use1904DateWindowing
 
     StreamingXSSFTabularData(InputStream inputStream,
                              StylesTable stylesTable,


### PR DESCRIPTION
Resolves a minor annoyance when extending `StreamingXSSFTabularData`.